### PR TITLE
CT Script Updates, Additional EMC, and Worldgen Correction

### DIFF
--- a/config/ProjectE/custom_emc.json
+++ b/config/ProjectE/custom_emc.json
@@ -423,6 +423,162 @@
     {
       "item": "techreborn:plates|28",
       "emc": 512
+    },
+    {
+      "item": "techreborn:dust|1",
+      "emc": 128
+    },
+    {
+      "item": "techreborn:dust|7",
+      "emc": 160
+    },
+    {
+      "item": "techreborn:dust|12",
+      "emc": 16
+    },
+    {
+      "item": "techreborn:dust|14",
+      "emc": 128
+    },
+    {
+      "item": "techreborn:dust|17",
+      "emc": 1280
+    },
+    {
+      "item": "techreborn:dust|23",
+      "emc": 512
+    },
+    {
+      "item": "techreborn:dust|24",
+      "emc": 2048
+    },
+    {
+      "item": "techreborn:dust|26",
+      "emc": 512
+    },
+    {
+      "item": "techreborn:dust|27",
+      "emc": 256
+    },
+    {
+      "item": "techreborn:dust|29",
+      "emc": 512
+    },
+    {
+      "item": "techreborn:dust|35",
+      "emc": 16
+    },
+    {
+      "item": "techreborn:dust|34",
+      "emc": 1024
+    },
+    {
+      "item": "techreborn:dust|36",
+      "emc": 2048
+    },
+    {
+      "item": "techreborn:dust|38",
+      "emc": 4096
+    },
+    {
+      "item": "techreborn:dust|43",
+      "emc": 2048
+    },
+    {
+      "item": "techreborn:dust|45",
+      "emc": 2048
+    },
+    {
+      "item": "techreborn:dust|47",
+      "emc": 512
+    },
+    {
+      "item": "techreborn:dust|51",
+      "emc": 512
+    },
+    {
+      "item": "techreborn:dust|53",
+      "emc": 256
+    },
+    {
+      "item": "thermalfoundation:material|0",
+      "emc": 256
+    },
+    {
+      "item": "thermalfoundation:material|1",
+      "emc": 2048
+    },
+    {
+      "item": "thermalfoundation:material|64",
+      "emc": 128
+    },
+    {
+      "item": "thermalfoundation:material|65",
+      "emc": 256
+    },
+    {
+      "item": "thermalfoundation:material|66",
+      "emc": 512
+    },
+    {
+      "item": "thermalfoundation:material|67",
+      "emc": 512
+    },
+    {
+      "item": "thermalfoundation:material|68",
+      "emc": 128
+    },
+    {
+      "item": "thermalfoundation:material|69",
+      "emc": 1024
+    },
+    {
+      "item": "thermalfoundation:material|70",
+      "emc": 4096
+    },
+    {
+      "item": "minecraft:coal|0",
+      "emc": 32
+    },
+    {
+      "item": "thermalfoundation:material|769",
+      "emc": 32
+    },
+    {
+      "item": "thermalfoundation:material|768",
+      "emc": 32
+    },
+    {
+      "item": "thermalfoundation:material|96",
+      "emc": 512
+    },
+    {
+      "item": "thermalfoundation:material|97",
+      "emc": 1280
+    },
+    {
+      "item": "thermalfoundation:material|98",
+      "emc": 512
+    },
+    {
+      "item": "thermalfoundation:material|99",
+      "emc": 160
+    },
+    {
+      "item": "thermalfoundation:material|100",
+      "emc": 576
+    },
+    {
+      "item": "thermalfoundation:material|101",
+      "emc": 384
+    },
+    {
+      "item": "thermalfoundation:material|102",
+      "emc": 704
+    },
+    {
+      "item": "thermalfoundation:material|103",
+      "emc": 1601
     }
   ]
 }

--- a/config/ProjectE/custom_emc.json
+++ b/config/ProjectE/custom_emc.json
@@ -235,6 +235,194 @@
     {
       "item": "contenttweaker:gc_mixed_metal|0",
       "emc": 800
+    },
+    {
+      "item": "galacticraftcore:heavy_plating|0",
+      "emc": 800
+    },
+    {
+      "item": "galacticraftcore:item_basic_moon|0",
+      "emc": 1024
+    },
+    {
+      "item": "galacticraftcore:item_basic_moon|1",
+      "emc": 512
+    },
+    {
+      "item": "galacticraftplanets:item_basic_mars|2",
+      "emc": 1024
+    },
+    {
+      "item": "galacticraftplanets:item_basic_mars|5",
+      "emc": 512
+    },
+    {
+      "item": "galacticraftplanets:item_basic_mars|3",
+      "emc": 1312
+    },
+    {
+      "item": "galacticraftplanets:item_basic_asteroids|5",
+      "emc": 1824
+    },
+    {
+      "item": "galacticraftcore:basic_item|6",
+      "emc": 128
+    },
+    {
+      "item": "galacticraftcore:basic_item|7",
+      "emc": 256
+    },
+    {
+      "item": "galacticraftcore:basic_item|8",
+      "emc": 128
+    },
+    {
+      "item": "galacticraftcore:basic_item|9",
+      "emc": 512
+    },
+    {
+      "item": "galacticraftcore:basic_item|10",
+      "emc": 160
+    },
+    {
+      "item": "galacticraftcore:basic_item|11",
+      "emc": 256
+    },
+    {
+      "item": "galacticraftcore:basic_block_moon|3",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftcore:basic_block_moon|4",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftcore:basic_block_moon|5",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:mars|4",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:mars|5",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:mars|6",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:mars|9",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:asteroids_block|0",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:asteroids_block|1",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:asteroids_block|2",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:venus|0",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:venus|1",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:venus|3",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftplanets:venus_rock_scorched|0",
+      "emc": 1
+    },
+    {
+      "item": "galacticraftcore:item_basic_moon|2",
+      "emc": 16384
+    },
+    {
+      "item": "techreborn:dust|18",
+      "emc": 16384
+    },
+    {
+      "item": "techreborn:smalldust|18",
+      "emc": 4096
+    },
+    {
+      "item": "techreborn:plates|6",
+      "emc": 16384
+    },
+    {
+      "item": "techreborn:plates|35",
+      "emc": 480
+    },
+    {
+      "item": "techreborn:plates|2",
+      "emc": 512
+    },
+    {
+      "item": "techreborn:dust|16",
+      "emc": 8192
+    },
+    {
+      "item": "techreborn:plates|0",
+      "emc": 256
+    },
+    {
+      "item": "techreborn:plates|1",
+      "emc": 2048
+    },
+    {
+      "item": "techreborn:plates|20",
+      "emc": 128
+    },
+    {
+      "item": "techreborn:plates|29",
+      "emc": 256
+    },
+    {
+      "item": "techreborn:plates|27",
+      "emc": 512
+    },
+    {
+      "item": "techreborn:plates|24",
+      "emc": 512
+    },
+    {
+      "item": "techreborn:plates|16",
+      "emc": 128
+    },
+    {
+      "item": "techreborn:plates|25",
+      "emc": 1024
+    },
+    {
+      "item": "techreborn:plates|26",
+      "emc": 4096
+    },
+    {
+      "item": "techreborn:plates|18",
+      "emc": 160
+    },
+    {
+      "item": "techreborn:plates|22",
+      "emc": 512
+    },
+    {
+      "item": "techreborn:plates|21",
+      "emc": 1280
+    },
+    {
+      "item": "techreborn:plates|28",
+      "emc": 512
     }
   ]
 }

--- a/config/cofh/world/00_minecraft.json
+++ b/config/cofh/world/00_minecraft.json
@@ -14,10 +14,9 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -35,10 +34,9 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -61,10 +59,9 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -87,10 +84,9 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -113,10 +109,9 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -134,10 +129,9 @@
 			"retrogen": true,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -155,10 +149,9 @@
 			"retrogen": true,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -176,10 +169,9 @@
 			"retrogen": true,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -197,10 +189,9 @@
 			"retrogen": true,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -218,10 +209,9 @@
 			"retrogen": true,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -239,10 +229,9 @@
 			"retrogen": true,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -278,10 +267,9 @@
 				]
 			},
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -304,10 +292,9 @@
 			"retrogen": true,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},

--- a/config/cofh/world/01_thermalfoundation_ores.json
+++ b/config/cofh/world/01_thermalfoundation_ores.json
@@ -14,10 +14,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -37,10 +36,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -60,10 +58,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -91,10 +88,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -122,10 +118,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -145,10 +140,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		}

--- a/config/cofh/world/02_thermalfoundation_oil.json
+++ b/config/cofh/world/02_thermalfoundation_oil.json
@@ -119,10 +119,9 @@
 				]
 			},
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -158,10 +157,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		}

--- a/config/cofh/world/03_thermalfoundation_clathrates.json
+++ b/config/cofh/world/03_thermalfoundation_clathrates.json
@@ -25,10 +25,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},

--- a/config/cofh/world/04_other_ores.json
+++ b/config/cofh/world/04_other_ores.json
@@ -14,10 +14,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		}

--- a/config/cofh/world/06_actuallyadditions_ores.json
+++ b/config/cofh/world/06_actuallyadditions_ores.json
@@ -17,10 +17,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		}

--- a/config/cofh/world/07_forestry_ores.json
+++ b/config/cofh/world/07_forestry_ores.json
@@ -14,10 +14,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		}

--- a/config/cofh/world/09_techreborn_ores.json
+++ b/config/cofh/world/09_techreborn_ores.json
@@ -17,10 +17,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -40,10 +39,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -88,10 +86,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		},
@@ -111,10 +108,9 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0
 				]
 			}
 		}

--- a/config/cofh/world/config.cfg
+++ b/config/cofh/world/config.cfg
@@ -1,8 +1,11 @@
 # Configuration file
 
-~CONFIG_VERSION: 1.1.1
+~CONFIG_VERSION: 1.2.0
 
 World {
+    # If TRUE, CoFH World will not generate features at all. This option is intended for use when you want another mod to handle ore generation but do not want to blank out the various .json files yourself. Flat Bedrock may still be used. [default: false]
+    B:DisableAllGeneration=false
+
     # If TRUE, standard Minecraft ore generation will be REPLACED. Configure in the 00_minecraft.json file; standard Minecraft defaults have been provided. If you rename the 00_minecraft.json file, this option WILL NOT WORK. [default: false]
     B:ReplaceStandardGeneration=true
 

--- a/resources/contenttweaker/lang/en_us.lang
+++ b/resources/contenttweaker/lang/en_us.lang
@@ -2,10 +2,10 @@ item.contenttweaker.plasticpurple.name=Purple Glazed Plastic
 item.contenttweaker.deathbook.name=Death Notebook
 item.contenttweaker.crystallattice.name=Crystalline Lattice
 
-//These get §9 to make them Blue like the Galacticraft Items.
+//These get ?9 to make them Blue like the Galacticraft Items.
 //Fancy must be preserved
-item.contenttweaker.gc_mixed_metal.name=§9Raw Heavy-Duty Composite
-item.contenttweaker.gc_alloy_metal.name=§9Heavy-Duty Ingot
+item.contenttweaker.gc_mixed_metal.name=Raw Heavy-Duty Composite
+item.contenttweaker.gc_alloy_metal.name=Heavy-Duty Ingot
 
 
 //Start of Super Secret
@@ -31,3 +31,4 @@ item.contenttweaker.food_beets_pickled.name=Pickled Beets
 item.contenttweaker.food_coffee_roasted.name=Coffee Beans (Roasted)
 item.contenttweaker.food_coffe_ground.name=Coffee Beans (Ground)
 item.contenttweaker.food_drink_cluckuccino.name=Cluckuccino
+item.contenttweaker.food_drink_coffee.name=Black Coffee

--- a/scripts/GalactiCraft.zs
+++ b/scripts/GalactiCraft.zs
@@ -1,6 +1,8 @@
 import mods.techreborn.alloySmelter;
 import mods.techreborn.compressor;
+import mods.thermalexpansion.Compactor;
 import mods.thermalexpansion.Imbuer;
+import mods.thermalexpansion.InductionSmelter;
 
 var ore_sapphire = <galacticraftcore:basic_block_moon:6>;
 var gem_sapphire = <galacticraftcore:item_basic_moon:2>;
@@ -8,40 +10,60 @@ var raw_desh = <galacticraftplanets:item_basic_mars:0>;
 var stick_desh = <galacticraftplanets:item_basic_mars:1>;
 var block_meteoric_iron = <galacticraftcore:basic_block_core:12>;
 
+var plateCopper = <ore:plateCopper>;
+var compressedCopper = <ore:compressedCopper>;
+var plateTin = <ore:plateTin>;
+var compressedTin = <ore:compressedTin>;
+var plateIron = <ore:plateIron>;
+var compressedIron = <ore:compressedIron>;
+var plateSteel = <ore:plateSteel>;
+var compressedSteel = <ore:compressedSteel>;
+var plateAluminum = <ore:plateAluminum>;
+var compressedAluminum = <ore:compressedAluminum>;
+var plateBronze = <ore:plateBronze>;
+var compressedBronze = <ore:compressedBronze>;
+var plateTitanium = <ore:plateTitanium>;
+var compressedTitanium = <ore:compressedTitanium>;
+
+<ore:oreTitanium>.add(<galacticraftplanets:asteroids_block:4>);
+
 <ore:dustDesh>.add(raw_desh);
 <ore:stickDesh).add(stick_desh);
 <ore:blockMeteoricIron>.add(block_meteoric_iron);
 
-
 <ore:oreLunarSapphire>.add(ore_sapphire);
 <ore:gemLunarSapphire>.add(gem_sapphire);
 
+compressedCopper.addAll(plateCopper);
+plateCopper.mirror(compressedCopper);
 
-<ore:plateCopper>.addAll(<ore:compressedCopper>);
-<ore:compressedCopper>.mirror(<ore:plateCopper>);
-<ore:plateTin>.addAll(<ore:compressedTin>);
-<ore:compressedTin>.mirror(<ore:plateTin>);
-<ore:plateAluminum>.addAll(<ore:compressedAluminum>);
-<ore:compressedAluminum>.addAll(<ore:plateAluminum>);
-<ore:plateSteel>.addAll(<ore:compressedSteel>);
-<ore:compressedSteel>.addAll(<ore:plateSteel>);
-<ore:plateBronze>.addAll(<ore:compressedBronze>);
-<ore:compressedBronze>.mirror(<ore:plateBronze>);
-<ore:plateIron>.addAll(<ore:compressedIron>);
-<ore:compressedIron>.mirror(<ore:plateIron>);
-<ore:plateMeteoricIron>.mirror(<ore:compressedMeteoricIron>);
-<ore:plateDesh>.mirror(<ore:compressedDesh>);
-<ore:plateTitanium>.addAll(<ore:compressedTitanium>);
-<ore:compressedTitanium>.mirror(<ore:plateTitanium>);
-<ore:circuitBasic>.addAll(<ore:waferBasic>);
-<ore:waferBasic>.mirror(<ore:circuitBasic>);
-<ore:circuitAdvanced>.addAll(<ore:waferAdvanced>);
-<ore:waferAdvanced>.mirror(<ore:circuitAdvanced>);
+compressedTin.addAll(plateTin);
+plateTin.mirror(compressedTin);
+
+compressedAluminum.addAll(plateAluminum);
+plateAluminum.mirror(compressedAluminum);
+
+compressedSteel.addAll(plateSteel);
+plateSteel.mirror(compressedSteel);
+
+compressedBronze.addAll(plateBronze);
+plateBronze.mirror(compressedBronze);
+
+compressedIron.addAll(plateIron);
+plateIron.mirror(compressedIron);
+
+compressedTitanium.addAll(plateTitanium);
+plateTitanium.mirror(compressedTitanium);
+
+<ore:waferBasic>.addAll(<ore:circuitBasic>);
+<ore:circuitBasic>.mirror(<ore:waferBasic>);
+
+<ore:waferAdvanced>.addAll(<ore:circuitAdvanced>);
+<ore:circuitAdvanced>.mirror(<ore:waferAdvanced>);
 
 <ore:plateHeavyDuty>.add(<galacticraftcore:heavy_plating>);
 <ore:plateHeavyDutyFeX>.add(<galacticraftplanets:item_basic_mars:3>);
 <ore:plateHeavyDutyDesh>.add(<galacticraftplanets:item_basic_asteroids:5>);
-
 
 <ore:ingotHeavyDuty>.add(<contenttweaker:gc_alloy_metal>);
 
@@ -49,11 +71,20 @@ recipes.addShaped(<contenttweaker:gc_mixed_metal> * 3, [[<ore:ingotSteel>,<ore:i
 
 furnace.addRecipe(<contenttweaker:gc_alloy_metal>,<contenttweaker:gc_mixed_metal>,1.6);
 
+//Recipes to Convert Desh and Meteoric Iron Ingots to Plates
+compressor.addRecipe(<galacticraftcore:item_basic_moon:1> * 2, <galacticraftcore:item_basic_moon>,200,4);
+Compactor.addPressRecipe(<galacticraftcore:item_basic_moon:1> * 2, <galacticraftcore:item_basic_moon>,4000);
+compressor.addRecipe(<galacticraftplanets:item_basic_mars:5> * 2, <galacticraftplanets:item_basic_mars:2>,200,4);
+Compactor.addPressRecipe(<galacticraftplanets:item_basic_mars:5> * 2, <galacticraftplanets:item_basic_mars:2>,4000);
+
+//Recipe to Convert Heavy-Duty Ingot into a Heavy-Duty Plate
 compressor.addRecipe(<galacticraftcore:heavy_plating>,<contenttweaker:gc_alloy_metal>,200,4);
 
-Imbuer.addRecipe(<liquid:fuel> * 10, <hatchery:chickenmanure>, <liquid:oxygen> * 500, 4000);
-
+//Recipes to convert Heavy-Duty Plates for both TE and TR
 alloySmelter.addRecipe(<galacticraftplanets:item_basic_mars:3>,<galacticraftcore:heavy_plating>,<galacticraftcore:item_basic_moon:1>,200,16);
-
+InductionSmelter.addRecipe(<galacticraftplanets:item_basic_mars:3>,<galacticraftcore:heavy_plating>,<galacticraftcore:item_basic_moon:1>,12000);
 alloySmelter.addRecipe(<galacticraftplanets:item_basic_asteroids:5>,<galacticraftplanets:item_basic_mars:3>,<galacticraftplanets:item_basic_mars:5>,200,16);
+InductionSmelter.addRecipe(<galacticraftplanets:item_basic_asteroids:5>,<galacticraftplanets:item_basic_mars:3>,<galacticraftplanets:item_basic_mars:5>,12000);
 
+//Fuel from Oxygen and Chicken Poop, RIP Brown Matter
+Imbuer.addRecipe(<liquid:fuel> * 10, <hatchery:chickenmanure>, <liquid:oxygen> * 500, 4000);

--- a/scripts/starcluckslite/starclucks_items.zs
+++ b/scripts/starcluckslite/starclucks_items.zs
@@ -85,9 +85,11 @@ food_beets_pickled.register();
 var food_drink_cluckuccino = VanillaFactory.createItemFood("food_drink_cluckuccino",6);
 food_drink_cluckuccino.itemUseAction = "DRINK";
 food_drink_cluckuccino.saturation = 1.2;
+food_drink_cluckuccino.alwaysEdible = true;
 food_drink_cluckuccino.register();
 
 var food_drink_coffee = VanillaFactory.createItemFood("food_drink_coffee",6);
 food_drink_coffee.itemUseAction = "DRINK";
 food_drink_coffee.saturation = 1.2;
+food_drink_coffee.alwaysEdible = true;
 food_drink_coffee.register();


### PR DESCRIPTION
 - Updated CT Scripts
   - Had to favor GC Plates over Others for Recipes to work properly
   - Made Black Coffee and Cluckuccino always Edibly.
     - It's always Coffee time
 - Added EMC to additional Items
    - Mostly Ingots and Dust and Plates from TechReborn, a few Thermal Foundation Items and Galacticraft as well however
 - Tweaked Worldgen
   - Made COFH Worldgen only generate in the overworld (or Nether where appropriate)
     - Changed All Options that where Blacklist for Dim 1,-1 into a Whitelist for Dim 0
