### PR TITLE
Updated CT Recipes to address Recipe Conflicts

### DIFF
--- a/scripts/GalactiCraft.zs
+++ b/scripts/GalactiCraft.zs
@@ -88,3 +88,12 @@ InductionSmelter.addRecipe(<galacticraftplanets:item_basic_asteroids:5>,<galacti
 
 //Fuel from Oxygen and Chicken Poop, RIP Brown Matter
 Imbuer.addRecipe(<liquid:fuel> * 10, <hatchery:chickenmanure>, <liquid:oxygen> * 500, 4000);
+
+//Charcoal Fragments
+recipes.removeByRecipeName("galacticraftplanets:carbon_fragments_alt_alt");
+
+//Silicon Conversion
+recipes.addShapeless(<galacticraftcore:basic_item:2>, [<refinedstorage:silicon>]);
+<galacticraftcore:basic_item:2>.addTooltip("Can be crafted into Refined Storage Silicon");
+recipes.addShapeless(<refinedstorage:silicon>, [<galacticraftcore:basic_item:2>]);
+<refinedstorage:silicon>.addTooltip("Can be crafted into Galacticraft Silicon");


### PR DESCRIPTION
Removed the Recipe for carbon fragments that's crafted with one charcoal, fixes #39 

Added Shapeless Recipes to convert Galacticraft and Refined Storage Silicon back and forth, acts as a work around for #32 