### PR TITLE
CT Script Fixes and Morpheus update

### DIFF
--- a/config/morpheus.cfg
+++ b/config/morpheus.cfg
@@ -2,14 +2,14 @@
 
 groundlevel {
     # Ground Level (1-255) [range: 1 ~ 255, default: 64]
-    I:settings=55
+    I:settings=64
 }
 
 
 settings {
     B:AlertEnabled=true
     B:AllowSetSpawnDaytime=true
-    B:IncludeMiners=true
+    B:IncludeMiners=false
     S:OnMorningText=Wakey, wakey, rise and shine... Good Morning everyone!
     S:OnSleepText=is now sleeping.
     S:OnWakeText=has left their bed.

--- a/scripts/FoodODFix.zs
+++ b/scripts/FoodODFix.zs
@@ -1,0 +1,11 @@
+
+recipes.replaceAllOccurences(<minecraft:egg>,<ore:egg>.onlyWithTag({}));
+
+//Fixes Pumpkin Pie
+recipes.remove(<minecraft:pumpkin_pie>);
+recipes.addShapeless(<minecraft:pumpkin_pie>,[<minecraft:pumpkin>,<ore:sugar>,<ore:egg>.onlyWithTag({})]);
+
+//Fixes AA Cheese (WHY DOES IT TAKE EGGS!?!?!)
+//recipes.remove(<actuallyadditions:item_food:0>);
+//recipes.addShapeless(<actuallyadditions:item_food:0>,[<minecraft:milk_bucket>,<ore:egg>.onlyWithTag({})]);
+

--- a/scripts/starcluckslite/starclucks_items.zs
+++ b/scripts/starcluckslite/starclucks_items.zs
@@ -63,7 +63,7 @@ food_pbj.register();
 
 var food_pbm = VanillaFactory.createItemFood("food_pbm",-5);
 food_pbm.saturation = 1.4;
-//food_pbm.alwaysEdible = true;
+food_pbm.alwaysEdible = true;
 food_pbm.register();
 
 var food_pie_fruit = VanillaFactory.createItemFood("food_pie_fruit", 10);

--- a/scripts/starcluckslite/starclucks_recipes.zs
+++ b/scripts/starcluckslite/starclucks_recipes.zs
@@ -72,6 +72,11 @@ recipes.addShapeless(<contenttweaker:food_mayo> * 4,[<ore:egg>,<ore:egg>,foodOil
 recipes.addShapeless(<contenttweaker:food_jam> * 4,[<ore:listAllfruit>,<ore:listAllfruit>,<ore:toolPot>,foodSugar]);
 recipes.addShapeless(<contenttweaker:food_nutbutter>,[listAllnut,listAllnut,toolPot,foodSugar]);
 
+//Tools
+recipes.addShaped(<contenttweaker:tool_knife>,[[<ore:nuggetIron>],[<ore:nuggetIron>],[<ore:stickWood>]]);
+recipes.addShaped(<contenttweaker:tool_pan>,[[ null,<ore:nuggetIron>,<ore:nuggetIron>],[<ore:stickWood>,<ore:ingotIron>,<ore:ingotIron>]]);
+recipes.addShaped(<contenttweaker:tool_pot>,[[ null,<ore:nuggetIron>,<ore:nuggetIron>],[<ore:stickWood>,<ore:nuggetIron>,<ore:nuggetIron>],[null,<ore:ingotIron>,<ore:ingotIron>]]);
+
 //Coffee
 recipes.addShapeless(<contenttweaker:food_drink_cluckuccino>*4,[toolPot,<ore:cropCoffee>,<minecraft:milk_bucket>]);
 recipes.addShapeless(<contenttweaker:food_drink_coffee>*4,[toolPot, <ore:cropCoffee>]);
@@ -95,7 +100,7 @@ recipes.addShapeless(<contenttweaker:food_pbm> *2,[breadAll,<contenttweaker:food
 
 //Pies
 recipes.addShapeless(<contenttweaker:food_pie_fruit>,[doughAll,foodSugar,<ore:listAllfruit>,<ore:listAllfruit>,toolKnife]);
-recipes.addShapeless(<contenttweaker:food_pie_nut>,[doughAll,foodSugar,<ore:listAllnuts>,<ore:listAllnuts>,toolKnife]);
+recipes.addShapeless(<contenttweaker:food_pie_nut>,[doughAll,foodSugar,<ore:listAllnut>,<ore:listAllnut>,toolKnife]);
 recipes.addShapeless(<contenttweaker:food_pie_meat>,[doughAll,rawBeef,<ore:cropPotato>,<ore:cropCarrot>,toolKnife]);
 recipes.addShapeless(<contenttweaker:food_pie_meat>,[doughAll,rawPork,<ore:cropPotato>,<ore:cropCarrot>,toolKnife]);
 recipes.addShapeless(<contenttweaker:food_pie_meat>,[doughAll,rawChicken,<ore:cropPotato>,<ore:cropCarrot>,toolKnife]);


### PR DESCRIPTION
Returned Morpheus ground level back to 64 since we're not using a Lost Cities world
Set Morpheus to not count those Mining

Fixed the Uncraftable Pumpkin Pie
Fixed Nut Butter recipe
Added Recipes for Knife, Pot, and Pan